### PR TITLE
fix: guard fast easy place ticks against invalid entity/block lookups

### DIFF
--- a/packs/BP/scripts/options/fastEasyPlace.js
+++ b/packs/BP/scripts/options/fastEasyPlace.js
@@ -86,6 +86,8 @@ function processEasyPlace(player) {
     if (!structureBlock)
         return;
     const worldBlock = player.dimension.getBlock(structureBlock.location);
+    if (!worldBlock)
+        return;
     if (locationsPlacedLastTick.has(JSON.stringify(worldBlock.location)))
         return;
     locationsPlacedLastTick.add(JSON.stringify(worldBlock.location));
@@ -103,10 +105,14 @@ function preventAction(event, player) {
 }
 
 function isHoldingActionItem(player) {
-    const mainhandItemStack = player.getComponent(EntityComponentTypes.Equippable).getEquipment(EquipmentSlot.Mainhand);
-    if (!mainhandItemStack)
+    try {
+        const mainhandItemStack = player.getComponent(EntityComponentTypes.Equippable).getEquipment(EquipmentSlot.Mainhand);
+        if (!mainhandItemStack)
+            return false;
+        return mainhandItemStack.typeId === ACTION_ITEM;
+    } catch {
         return false;
-    return mainhandItemStack.typeId === ACTION_ITEM;
+    }
 }
 
 function tryPlaceBlock(player, worldBlock, structureBlock) {


### PR DESCRIPTION
Fixes #18

This hardens the fast easy place tick path in two spots:

- Return early when `dimension.getBlock()` returns no block.
- Wrap mainhand equipment lookup in `isHoldingActionItem()` with a safe fallback to prevent `InvalidEntityError` from bubbling and spamming logs.

The placement behavior remains unchanged for valid entities/targets, but noisy backend errors are suppressed for transient invalid states.

Greetings, saschabuehrle